### PR TITLE
Docs and config quick wins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Environment variables for the SvelteKit frontend.
+#
+# Copy this file to `.env` and fill in any values you want to override.
+# `.env` is gitignored.
+#
+# As of now the app reads no user-settable env vars; the only runtime switch
+# is Vite's built-in `import.meta.env.DEV`, which is set automatically.
+#
+# Variables planned for extraction (see issue #17):
+#
+# PUBLIC_API_URL=https://api.log.ddev.site/api/graphql

--- a/README.md
+++ b/README.md
@@ -1,38 +1,61 @@
-# create-svelte
+# the-log/svelte
 
-Everything you need to build a Svelte project, powered by [`create-svelte`](https://github.com/sveltejs/kit/tree/master/packages/create-svelte).
+SvelteKit frontend for the fantasy football league management app. Reads from the Keystone GraphQL backend (`api.log.football` in prod, `api.log.ddev.site` locally) and is deployed to Netlify.
 
-## Creating a project
+## Quick start
 
-If you're seeing this, you've probably already done this step. Congrats!
-
-```bash
-# create a new project in the current directory
-npm create svelte@latest
-
-# create a new project in my-app
-npm create svelte@latest my-app
-```
-
-## Developing
-
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+The recommended local workflow uses [DDEV](https://ddev.com/), which orchestrates this app alongside its backend and scraper siblings:
 
 ```bash
-npm run dev
-
-# or start the server and open the app in a new browser tab
-npm run dev -- --open
+# from the parent project directory (where .ddev/ lives)
+ddev start
+ddev svelte         # runs `npm run dev` inside the container
 ```
 
-## Building
+The dev server listens on `:3001` and is reachable at <https://app.log.ddev.site>.
 
-To create a production version of your app:
+To run outside DDEV (frontend-only, pointed at the prod backend):
 
 ```bash
-npm run build
+cd svelte
+npm install
+npm run dev         # http://localhost:3001
 ```
 
-You can preview the production build with `npm run preview`.
+## Scripts
 
-> To deploy your app, you may need to install an [adapter](https://kit.svelte.dev/docs/adapters) for your target environment.
+| Script | Purpose |
+|---|---|
+| `npm run dev` | Start the dev server on port 3001. |
+| `npm run build` | Build for production (used by Netlify). |
+| `npm run preview` | Preview the production build locally. |
+| `npm run check` | Run `svelte-check` for type errors. |
+| `npm run lint` | Prettier + ESLint check. |
+| `npm run format` | Apply Prettier formatting. |
+
+## Stack
+
+- **Framework**: SvelteKit (adapter-netlify, edge functions)
+- **UI**: Shoelace web components, loaded via CDN autoloader in `src/app.html`
+- **Data**: GraphQL via a thin `fetch` wrapper in `src/utils/runQuery.ts`
+- **Markdown**: `marked` (used by the rulebook route)
+
+## Project layout
+
+```
+src/
+  app.html              Shell — Shoelace bootstrap, design tokens
+  routes/               SvelteKit pages
+  components/           Reusable Svelte components
+  utils/                Pure helpers, GraphQL client, query strings
+  types/                TypeScript types and GraphQL schema types
+  misc/stores.ts        Svelte stores (auth, etc.)
+```
+
+## Environment
+
+See `.env.example`. The app currently reads only Vite's built-in `import.meta.env.DEV` to switch backend URLs; user-settable env vars are tracked in [issue #17](https://github.com/the-log/svelte/issues/17).
+
+## Deployment
+
+Netlify auto-deploys from `main`. Build config lives in `netlify.toml`.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
-  command = "yarn build"
+  command = "npm run build"
   publish = "build"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,6 @@
 [build]
   command = "npm run build"
   publish = "build"
+
+[build.environment]
+  NODE_VERSION = "22"


### PR DESCRIPTION
Closes #18.

Phase 1 of the [quick-wins block plan](https://github.com/the-log/svelte/issues/18) — pure docs/config, no source or dependency changes.

## Changes
- **`netlify.toml`**: build command `yarn build` → `npm run build` (the project uses npm; `package-lock.json` is checked in, no `yarn.lock`). Also pins `NODE_VERSION = "22"` so Netlify stops failing on its default-too-old runtime — matches the DDEV Node 22 LTS used locally.
- **`README.md`**: replace the unchanged `create-svelte` boilerplate with project-specific setup notes — quick start (DDEV + npm), scripts table, stack overview, project layout, env pointer.
- **`.env.example`** *(new)*: placeholder file. The app currently reads no user-settable env vars (only Vite's built-in `import.meta.env.DEV`), so the file just documents what's planned in #17.

## Test plan
- [ ] `npm run dev` — dev server starts on :3001, home page loads.
- [ ] README renders cleanly on GitHub.
- [ ] Netlify deploy preview for this branch builds successfully on Node 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)